### PR TITLE
rewrote discriminator to incorporate maxpooling and added a MLP layer

### DIFF
--- a/classes/discriminator.py
+++ b/classes/discriminator.py
@@ -1,31 +1,72 @@
 import torch.nn as nn
 from constants import ndf, nc
 
+
+# going to assume input image is 2048 x 1024 rather than 1980 x 1080 for numerical simplicty
+# 13 109 697 parameters (ndf = 64) -- I think it should be smaller 
+# Conv: ~ 4.7M params , MLP: ~ 8.4M params. Scales quadratically with ndf.
+# Probably want dropout at some point to stop overfitting
 class Discriminator(nn.Module):
-    def __init__(self, ngpu):
+    def __init__(self, ngpu, dropout = 0.0):
         super(Discriminator, self).__init__()
         self.ngpu = ngpu
+
+        #Convolutional part
+        self.conv = nn.Sequential(
+            # input is ``(nc) x 2048 x 1024``
+            DoubleConv(nc, ndf, dropout=dropout),
+            nn.MaxPool2d(4),
+            # state size. ``(ndf) x 512 x 256``
+            DoubleConv(ndf, ndf*2, dropout=dropout),
+            nn.MaxPool2d(4),
+            # state size. ``(ndf*2) x 128 x 64``
+            DoubleConv(ndf*2, ndf*4, dropout=dropout),
+            nn.MaxPool2d(4),
+            # state size. ``(ndf*4) x 32 x 16``
+            DoubleConv(ndf*4, ndf*8, dropout=dropout),
+            nn.MaxPool2d(4),
+            # state size. ``(ndf*8) x 8 x 4``
+        )
+
+        # Dense layers to process the CNN output
+        self.MLP = nn.Sequential(
+            nn.LayerNorm(ndf * 8 * 8 * 4),
+            nn.Linear(ndf * 8 * 8 * 4, ndf * 8),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Linear(ndf * 8, 1),
+            nn.Dropout(dropout)
+        )
+        
+    def forward(self, input):
+        x = self.conv(input)
+        x = x.flatten()
+        x = self.MLP(x)
+        x = nn.functional.sigmoid(x)
+        return x
+    
+# 2 convolutional layers with gelu nonlinearity in between, 
+# first layer increases channel number (unless otherwise specified)
+# best practices (I think) to use group norm rather than batch norm 
+# https://medium.com/@zljdanceholic/groupnorm-then-batchnorm-instancenorm-layernorm-e2b2a1d350a0
+class DoubleConv(nn.Module):
+
+    def __init__(self, c_in, c_out, c_mid = None, dropout = 0.0):
+        super().__init__()
+        if not c_mid:
+            c_mid = c_out
+
         self.main = nn.Sequential(
-            # input is ``(nc) x 64 x 64``
-            nn.Conv2d(nc, ndf, 4, 2, 1, bias=False),
+            nn.Conv2d(c_in, c_mid, kernel_size=3, padding='same', bias=False),
+            nn.GroupNorm(1,c_mid),
             nn.LeakyReLU(0.2, inplace=True),
-            # state size. ``(ndf) x 32 x 32``
-            nn.Conv2d(ndf, ndf * 2, 4, 2, 1, bias=False),
-            nn.BatchNorm2d(ndf * 2),
-            nn.LeakyReLU(0.2, inplace=True),
-            # state size. ``(ndf*2) x 16 x 16``
-            nn.Conv2d(ndf * 2, ndf * 4, 4, 2, 1, bias=False),
-            nn.BatchNorm2d(ndf * 4),
-            nn.LeakyReLU(0.2, inplace=True),
-            # state size. ``(ndf*4) x 8 x 8``
-            nn.Conv2d(ndf * 4, ndf * 8, 4, 2, 1, bias=False),
-            nn.BatchNorm2d(ndf * 8),
-            nn.LeakyReLU(0.2, inplace=True),
-            # state size. ``(ndf*8) x 4 x 4``
-            nn.Conv2d(ndf * 8, 1, 4, 1, 0, bias=False),
-            nn.Sigmoid()
+            nn.Conv2d(c_mid, c_out, kernel_size=3, padding='same', bias=False),
+            nn.GroupNorm(1,c_out),
+            nn.Dropout(dropout)
         )
 
     def forward(self, input):
         return self.main(input)
+
+
+
 


### PR DESCRIPTION
New architecture has 2 layers of convolution with a leaky ReLU in between, followed by a 4x4 maxpool. Total number of tensors being passed through goes down by 8x per pass through. Also added in a dropout layer to prevent overfitting in the future. Assumes that image being passed in is 2048x1024 rather than 1980 x 1080. 

ndf is quite large -- if you decrease it to 16 or something it wouldn't be unreasonable to add in more convolutional layers and only use 2x2 maxpool. 